### PR TITLE
Move routes that use adminMiddleware around

### DIFF
--- a/src/app/routes/event.routes.js
+++ b/src/app/routes/event.routes.js
@@ -4,7 +4,7 @@ import express from 'express';
 
 import eventController from '../controllers/event.controller';
 
-import { authMiddleware, wrap } from '../middleware';
+import { wrap, adminMiddleware } from '../middleware';
 import { NotFoundError } from '../errors';
 
 export default function(app: express$Application) {
@@ -12,8 +12,8 @@ export default function(app: express$Application) {
 
     const getEventPage = async (req: $Request, res: $Response) => {
         const events = await eventController.getEvents();
-    
-        res.json({ 
+
+        res.json({
             events: events ? events : [],
         });
     };
@@ -25,7 +25,7 @@ export default function(app: express$Application) {
         res.json({ event });
     };
 
-    eventRouter.use(authMiddleware);
+    eventRouter.use(adminMiddleware);
     eventRouter.get('/', wrap(getEventById));
     eventRouter.get('/all', wrap(getEventPage));
 

--- a/src/app/routes/user.routes.js
+++ b/src/app/routes/user.routes.js
@@ -81,12 +81,12 @@ export default function(app: express$Application) {
         res.json(result);
     };
 
-    userRouter.use(authMiddleware);
-    userRouter.get('/', wrap(getSingleUser));
-    userRouter.get('/all', wrap(getUserPage));
     userRouter.get('/info/all', adminMiddleware, wrap(getUserDataPage));
     userRouter.post('/check-in', adminMiddleware, wrap(checkUserIntoEvent))
     userRouter.delete('/:id', adminMiddleware, wrap(deleteUserById));
+    userRouter.use(authMiddleware);
+    userRouter.get('/', wrap(getSingleUser));
+    userRouter.get('/all', wrap(getUserPage));
 
     app.use('/user', userRouter);
 }


### PR DESCRIPTION
I had some issues with using a gatekey to access the routes that I changed. Is it the right solution to load the adminMiddleware before the authMiddleware? The backend performs as expected after these changes were made.